### PR TITLE
Group email lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # stuyactivities.org
 
 The front-end for the new StuyActivities site.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # stuyactivities.org
 
 The front-end for the new StuyActivities site.

--- a/src/pages/org/admin/groups.js
+++ b/src/pages/org/admin/groups.js
@@ -190,12 +190,18 @@ export default function Groups({ match }) {
 								<ListItem key={group.id} fullWidth>
 									<Grid container xl={12} lg={12} md={12} sm={12} xs={12} direction="column">
 										<Grid container justifyContent="space-between">
-											<Typography variant="h5" align="left">{group.name}</Typography>
+											<Typography variant="h5" align="left">
+												{group.name}
+											</Typography>
 											<Button
-												onClick={
-													() => navigator.clipboard.writeText(
-														group?.memberships.map(membership => membership.user.email).join(", ")
-													).then(() => setSnackBarOpen(true))
+												onClick={() =>
+													navigator.clipboard
+														.writeText(
+															group?.memberships
+																.map(membership => membership.user.email)
+																.join(", ")
+														)
+														.then(() => setSnackBarOpen(true))
 												}
 												color={"primary"}
 												variant={"contained"}

--- a/src/pages/org/admin/groups.js
+++ b/src/pages/org/admin/groups.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { gql, useMutation, useQuery } from "@apollo/client";
+import { useSnackbar } from 'notistack';
 import {
 	Avatar,
 	Box,
@@ -150,7 +151,7 @@ export default function Groups({ match }) {
 		setEditGroup({});
 	};
 
-	const [snackBarOpen, setSnackBarOpen] = React.useState(false);
+	const { enqueueSnackbar, closeSnackbar } = useSnackbar();
 
 	return (
 		<div className={classes.margin}>
@@ -201,7 +202,14 @@ export default function Groups({ match }) {
 																.map(membership => membership.user.email)
 																.join(", ")
 														)
-														.then(() => setSnackBarOpen(true))
+														.then(() => enqueueSnackbar("Copied email list to clipboard!", {
+															anchorOrigin: {
+												        vertical: 'bottom',
+												        horizontal: 'center',
+												    	},
+															autoHideDuration:3000,
+														}
+													))
 												}
 												color={"primary"}
 												variant={"contained"}
@@ -354,12 +362,6 @@ export default function Groups({ match }) {
 						<Button onClick={() => setEditGroup({})}>Close</Button>
 					</DialogActions>
 				</Dialog>
-				<Snackbar
-					open={snackBarOpen}
-					autoHideDuration={3000}
-					onClose={() => setSnackBarOpen(false)}
-					message="Copied email list to clipboard!"
-				/>
 			</List>
 		</div>
 	);

--- a/src/pages/org/admin/groups.js
+++ b/src/pages/org/admin/groups.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { gql, useMutation, useQuery } from "@apollo/client";
-import { useSnackbar } from 'notistack';
+import { useSnackbar } from "notistack";
 import {
 	Avatar,
 	Box,
@@ -202,14 +202,15 @@ export default function Groups({ match }) {
 																.map(membership => membership.user.email)
 																.join(", ")
 														)
-														.then(() => enqueueSnackbar("Copied email list to clipboard!", {
-															anchorOrigin: {
-												        vertical: 'bottom',
-												        horizontal: 'center',
-												    	},
-															autoHideDuration:3000,
-														}
-													))
+														.then(() =>
+															enqueueSnackbar("Copied email list to clipboard!", {
+																anchorOrigin: {
+																	vertical: "bottom",
+																	horizontal: "center"
+																},
+																autoHideDuration: 3000
+															})
+														)
 												}
 												color={"primary"}
 												variant={"contained"}

--- a/src/pages/org/admin/groups.js
+++ b/src/pages/org/admin/groups.js
@@ -15,6 +15,7 @@ import {
 	ListItemAvatar,
 	ListItemSecondaryAction,
 	makeStyles,
+	Snackbar,
 	TextField,
 	Typography
 } from "@material-ui/core";
@@ -149,6 +150,8 @@ export default function Groups({ match }) {
 		setEditGroup({});
 	};
 
+	const [snackBarOpen, setSnackBarOpen] = React.useState(false);
+
 	return (
 		<div className={classes.margin}>
 			<Card>
@@ -186,7 +189,21 @@ export default function Groups({ match }) {
 							<Box p={1}>
 								<ListItem key={group.id} fullWidth>
 									<Grid container xl={12} lg={12} md={12} sm={12} xs={12} direction="column">
-										<Typography variant="h5">{group.name}</Typography>
+										<Grid container justifyContent="space-between">
+											<Typography variant="h5" align="left">{group.name}</Typography>
+											<Button
+												onClick={
+													() => navigator.clipboard.writeText(
+														group?.memberships.map(membership => membership.user.email).join(", ")
+													).then(() => setSnackBarOpen(true))
+												}
+												color={"primary"}
+												variant={"contained"}
+												size={"small"}
+											>
+												Copy Emails
+											</Button>
+										</Grid>
 										<List>
 											{group.memberships.length > 0 ? (
 												group.memberships.map(membership => (
@@ -331,6 +348,12 @@ export default function Groups({ match }) {
 						<Button onClick={() => setEditGroup({})}>Close</Button>
 					</DialogActions>
 				</Dialog>
+				<Snackbar
+					open={snackBarOpen}
+					autoHideDuration={3000}
+					onClose={() => setSnackBarOpen(false)}
+					message="Copied email list to clipboard!"
+				/>
 			</List>
 		</div>
 	);

--- a/src/pages/org/admin/groups.js
+++ b/src/pages/org/admin/groups.js
@@ -16,7 +16,6 @@ import {
 	ListItemAvatar,
 	ListItemSecondaryAction,
 	makeStyles,
-	Snackbar,
 	TextField,
 	Typography
 } from "@material-ui/core";
@@ -151,7 +150,7 @@ export default function Groups({ match }) {
 		setEditGroup({});
 	};
 
-	const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+	const { enqueueSnackbar } = useSnackbar();
 
 	return (
 		<div className={classes.margin}>


### PR DESCRIPTION
Adds a button in the group tab of the admin panel that copies the list of the email addresses of a group. 
![Screen Shot 2022-01-28 at 9 41 59 PM](https://user-images.githubusercontent.com/25336089/151644221-137b93b6-9e55-481e-b9b5-fb31b245ca29.png)

