### PR TITLE
Don't rewrite text fields until limits are hit

### DIFF
--- a/src/comps/pages/charter/SmartCharterQuestion.js
+++ b/src/comps/pages/charter/SmartCharterQuestion.js
@@ -48,14 +48,15 @@ const SmartCharterQuestion = ({
 
 	const onChange = ev => {
 		let value = ev.target.value;
-		if (maxChars) {
-			value = value.substr(0, maxChars);
+		if (maxChars && value.length > maxChars) {
+			value = value.slice(0, maxChars);
 		}
 
 		if (maxWords) {
-			let words = value.split(" ");
-			words = words.filter((val, index) => Boolean(val) || index === words.length - 1).slice(0, maxWords);
-			value = words.join(" ");
+			const words = value.split(" ");
+			if (words.length > maxWords) {
+				value = words.slice(0, maxWords).join(" ");
+			}
 		}
 
 		form.setError(name, false);


### PR DESCRIPTION
Fixes a bug when trying to insert new words into a word-limited charter question. Also replaces the [deprecated String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr).